### PR TITLE
added option tapeColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ There are some options that are available to you as well:
   typeDelay         : 200,
   clearOnHighlight  : true,
   typerDataAttr     : 'data-typer-targets',
-  typerInterval     : 2000
+  typerInterval     : 2000,
+  tapeColor         : 'auto' // 'auto' or a css color value
 }
 ```
 

--- a/src/jquery.typer.js
+++ b/src/jquery.typer.js
@@ -19,7 +19,8 @@ String.prototype.rightChars = function(n){
       typeDelay         : 200,
       clearOnHighlight  : true,
       typerDataAttr     : 'data-typer-targets',
-      typerInterval     : 2000
+      typerInterval     : 2000,
+      tapeColor         : 'auto'
     },
     highlight,
     clearText,
@@ -130,7 +131,7 @@ String.prototype.rightChars = function(n){
       .append(
         spanWithColor(
             $e.data('backgroundColor'),
-            $e.data('primaryColor')
+            $.typer.options.tapeColor === 'auto' ? $e.data('primaryColor') : $.typer.options.tapeColor
           )
           .append(highlightedText)
       )
@@ -224,7 +225,7 @@ String.prototype.rightChars = function(n){
     $e.data('oldRight', currentText.rightChars(j - 1));
     $e.data('leftStop', i);
     $e.data('rightStop', currentText.length - j);
-    $e.data('primaryColor', $e.css('color'));
+    $e.data('primaryColor', $.typer.options.tapeColor === 'auto' ? $e.data('primaryColor') : $.typer.options.tapeColor);
     $e.data('backgroundColor', $e.css('background-color'));
     $e.data('text', newString);
     highlight($e);

--- a/test.html
+++ b/test.html
@@ -2,8 +2,12 @@
 <html>
 <head>
 </head>
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-  <script src="/src/jquery.typer.js"></script>
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+  <script src="src/jquery.typer.js"></script>
+  <style type="text/css">
+    h3 { color: blue; }
+    .cyan { background-color: cyan; padding: 1em; }
+  </style>
 <body>
 
   <h1>Hello, World!</h1>
@@ -11,9 +15,21 @@
 
   <h2 data-typer-targets="abcdefgfedcba,afgfa">Welcome</h2>
 
+  <h3 data-typer-targets="foobar,lorem,ipsum">Hello World!</h3>
+
+  <div class="cyan">
+    <h3 data-typer-targets="foobar,lorem,ipsum">Hello World!</h3>
+  </div>
+
+  <p id="test"></p>
+
   <script>
     $(function () {
+      $.typer.options.tapeColor = 'orange';
+      //$.typer.options.tapeColor = '#ff9900';
       $('[data-typer-targets]').typer();
+
+      $('#test').typeTo('Hello World');
     });
   </script>
 </body>


### PR DESCRIPTION
I added a $.typer.option.tapeColor option that let's developers overwrite the standard behviour of overwriting the text with a "color tape" the same color as the initial font color and instead a custom color can be provided.

This is a potential fix for issue #3 
