### PR TITLE
jQuery chaining fixed

### DIFF
--- a/src/jquery.typer.js
+++ b/src/jquery.typer.js
@@ -50,15 +50,16 @@ String.prototype.rightChars = function(n){
   };
 
   clearData = function ($e) {
-    $e
-      .data('typePosition',       null)
-      .data('highlightPosition',  null)
-      .data('leftStop',           null)
-      .data('rightStop',          null)
-      .data('primaryColor',       null)
-      .data('backgroundColor',    null)
-      .data('text',               null)
-      .data('typing',             null);
+    $e.removeData([
+      'typePosition',
+      'highlightPosition',
+      'leftStop',
+      'rightStop',
+      'primaryColor',
+      'backgroundColor',
+      'text',
+      'typing'
+    ]);
   };
 
   type = function ($e) {
@@ -82,10 +83,11 @@ String.prototype.rightChars = function(n){
       oldLeft +
       text.charAt(0) +
       oldRight
-    );
+    ).data({
+      oldLeft: oldLeft + text.charAt(0),
+      text: text.substring(1)
+    });
 
-    $e.data('oldLeft', oldLeft + text.charAt(0));
-    $e.data('text', text.substring(1));
     // $e.text($e.text() + text.substring(position, position + 1));
 
     // $e.data('typePosition', position + 1);
@@ -125,8 +127,7 @@ String.prototype.rightChars = function(n){
     highlightedText = $e.text().substring(position - 1, $e.data('rightStop') + 1);
     rightText = $e.text().substring($e.data('rightStop') + 1);
 
-    $e.html(leftText);
-    $e
+    $e.html(leftText)
       .append(
         spanWithColor(
             $e.data('backgroundColor'),
@@ -177,12 +178,12 @@ String.prototype.rightChars = function(n){
   $.fn.typer = function() {
     var $elements = $(this);
 
-    $elements = $elements.filter(function () {
-      return typeof $(this).attr($.typer.options.typerDataAttr) !== "undefined"
-    });
-
-    $elements.each(function () {
+    return $elements.each(function () {
       var $e = $(this);
+
+      if (typeof $e.attr($.typer.options.typerDataAttr) === "undefined") {
+        return;
+      }
 
       typeWithAttribute($e);
       setInterval(function () {
@@ -200,12 +201,12 @@ String.prototype.rightChars = function(n){
 
     if (currentText === newString) {
       console.log("Our strings our equal, nothing to type");
-      return;
+      return $e;
     }
 
     if (currentText !== $e.html()) {
       console.error("Typer does not work on elements with child elements.");
-      return;
+      return $e;
     }
 
     $e.data('typing', true);
@@ -220,14 +221,19 @@ String.prototype.rightChars = function(n){
 
     newString = newString.substring(i, newString.length - j + 1);
 
-    $e.data('oldLeft', currentText.substring(0, i));
-    $e.data('oldRight', currentText.rightChars(j - 1));
-    $e.data('leftStop', i);
-    $e.data('rightStop', currentText.length - j);
-    $e.data('primaryColor', $e.css('color'));
-    $e.data('backgroundColor', $e.css('background-color'));
-    $e.data('text', newString);
+    $e.data({
+      oldLeft: currentText.substring(0, i),
+      oldRight: currentText.rightChars(j - 1),
+      leftStop: i,
+      rightStop: currentText.length - j,
+      primaryColor: $e.css('color'),
+      backgroundColor: $e.css('background-color'),
+      text: newString
+    });
+
     highlight($e);
+
+    return $e;
   };
 
   //-- Helper methods. These can one day be customized further to include things like ranges of delays.


### PR DESCRIPTION
This fixes [#10](https://github.com/layervault/jquery.typer.js/issues/10). By convention, all `$.fn.*` methods return the original jQuery object to allow chaining. I fixed this, and rewritten some minor portions of the code using jQuery’s chaining power.

I added a few comments on the diff, with more explanations.
