### PR TITLE
Add the ability for typer.js to rewrite the whole string rather than being 'smart' about it.

### DIFF
--- a/src/jquery.typer.js
+++ b/src/jquery.typer.js
@@ -18,6 +18,7 @@ String.prototype.rightChars = function(n){
       clearDelay        : 500,
       typeDelay         : 200,
       clearOnHighlight  : true,
+      highlightEverything: true,
       typerDataAttr     : 'data-typer-targets',
       typerInterval     : 2000
     },
@@ -211,12 +212,14 @@ String.prototype.rightChars = function(n){
 
     $e.data('typing', true);
 
-    while (currentText.charAt(i) === newString.charAt(i)) {
-      i++;
-    }
+    if ($.typer.options.highlightEverything !== true) {
+      while (currentText.charAt(i) === newString.charAt(i)) {
+        i++;
+      }
 
-    while (currentText.rightChars(j) === newString.rightChars(j)) {
-      j++;
+      while (currentText.rightChars(j) === newString.rightChars(j)) {
+        j++;
+      }
     }
 
     newString = newString.substring(i, newString.length - j + 1);


### PR DESCRIPTION
In certain cases it looks better if the whole string is replaced rather than the difference. This PR allows typer.js to replace the whole string.
